### PR TITLE
refactor(docker): use multi staged alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.1-alpine
+FROM golang:1.20.1-alpine as builder
 
 WORKDIR /usr/src/goctopus
 
@@ -9,4 +9,6 @@ RUN go mod download && go mod verify
 COPY . .
 RUN go build -v -o /usr/local/bin/goctopus ./cmd/goctopus/goctopus.go
 
-ENTRYPOINT [ "goctopus" ]
+FROM alpine:3.14
+COPY --from=builder /usr/local/bin/goctopus ./goctopus
+ENTRYPOINT [ "./goctopus" ]


### PR DESCRIPTION
Use multi-staged docker build to ship the image with alpine.
This will drastically reduce the end-image size. ( ~740MB)

```
goctopus-alpine                            latest    c1f3cc4aa19e   16 minutes ago   20.2MB
escapetech/goctopus                        latest    c3b686c9d39d   4 days ago       761MB
```