### PR TITLE
fix: authentication quantic state

### DIFF
--- a/pkg/endpoint/fingerprint.go
+++ b/pkg/endpoint/fingerprint.go
@@ -23,16 +23,16 @@ func fingerprintEndpoint(url *address.Addr, e endpointFingerprinter, config *con
 		return nil, err
 	}
 
-	isAuthenticatedGraphql, err := e.IsAuthenticatedGraphql()
-	if err != nil {
-		return nil, err
-	}
+	if !isOpenGraphql {
+		isAuthenticatedGraphql, err := e.IsAuthenticatedGraphql()
+		if err != nil {
+			return nil, err
+		}
 
-	if !isOpenGraphql && !isAuthenticatedGraphql {
-		return nil, ErrNotGraphql
-	}
+		if !isAuthenticatedGraphql {
+			return nil, ErrNotGraphql
+		}
 
-	if isAuthenticatedGraphql {
 		out.Authenticated = true
 		return out, nil
 	}

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -41,15 +41,10 @@ func marshalOutput(o *FingerprintOutput, c *config.Config) ([]byte, error) {
 		panic(err)
 	}
 
-	// // remove the introspection field if it is disabled
-	// if !c.Introspection {
-	// 	delete(outputMap, "introspection")
-	// }
-
-	// // if introspection is enabled, remove the field_suggestion field
-	// if !c.FieldSuggestion || o. {
-	// 	delete(outputMap, "field_suggestion")
-	// }
+	// remove the schema_status field if introsepction is disabled
+	if !c.Introspection {
+		delete(outputMap, "schema_status")
+	}
 
 	// when scanning from an url, the domain is not set so we infer it from the url
 	if o.Domain == "" && o.Url != "" {

--- a/pkg/output/output_test.go
+++ b/pkg/output/output_test.go
@@ -56,7 +56,7 @@ func TestMarshallOutput(t *testing.T) {
 				Introspection:   false,
 				FieldSuggestion: false,
 			},
-			`{"domain":"` + domain + `","url":"` + url + `","authenticated":false,"schema_status":"` + string(SchemaStatusClosed) + `",` + `"source":"` + source + `"}`,
+			`{"domain":"` + domain + `","url":"` + url + `","authenticated":false, "source":"` + source + `"}`,
 		},
 	}
 	for _, table := range tables {


### PR DESCRIPTION
- Fixes a bug where it is considered authenticated if an api returns a valid response + errors simultaneously.
- Hides `schema_status` if introspection fingerprinting is disabled.